### PR TITLE
refactor(query): centralise React Query keys in a key factory

### DIFF
--- a/src/app/(site)/owner/chats/ChatsUI.tsx
+++ b/src/app/(site)/owner/chats/ChatsUI.tsx
@@ -10,6 +10,7 @@ import { useChatsQuery } from "@/hooks/chats/useChats";
 import { useChatSocket } from "@/hooks/chats/useChatSocket";
 import { useCurrentUserId } from "@/hooks/useCurrentUserId";
 import { getChatMessages } from "@/services/chats/getChatMessages";
+import { queryKeys } from "@/lib/queryKeys";
 
 export default function ChatsUI() {
   const router = useRouter();
@@ -27,7 +28,7 @@ export default function ChatsUI() {
   useEffect(() => {
     if (!chats) return;
     chats.forEach(chat => {
-      const key = ["chatMessages", String(chat.chatId)];
+      const key = queryKeys.chatMessages.byChat(String(chat.chatId));
       const existing = queryClient.getQueryData(key);
       if (existing) return;
       queryClient.prefetchInfiniteQuery({

--- a/src/hooks/auth/useSignIn.ts
+++ b/src/hooks/auth/useSignIn.ts
@@ -2,6 +2,7 @@
 
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { signIn } from "@/services/auth/signIn";
+import { queryKeys } from "@/lib/queryKeys";
 
 export function useSignIn() {
   const queryClient = useQueryClient();
@@ -11,7 +12,7 @@ export function useSignIn() {
 
     onSuccess: async () => {
       await queryClient.invalidateQueries({
-        queryKey: ["profile"],
+        queryKey: queryKeys.profile,
       });
     },
   });

--- a/src/hooks/chats/useCachedChatMessages.ts
+++ b/src/hooks/chats/useCachedChatMessages.ts
@@ -1,16 +1,17 @@
 import { useEffect, useState } from "react";
 import { useQueryClient, InfiniteData } from "@tanstack/react-query";
 import { PaginatedMessagesResponse } from "@/types/chatsTypes";
+import { queryKeys } from "@/lib/queryKeys";
 
 export function useCachedChatMessages(chatId: string) {
   const queryClient = useQueryClient();
 
   const [data, setData] = useState<InfiniteData<PaginatedMessagesResponse> | undefined>(
-    () => queryClient.getQueryData(["chatMessages", chatId])
+    () => queryClient.getQueryData(queryKeys.chatMessages.byChat(chatId))
   );
 
   useEffect(() => {
-    const queryKey = ["chatMessages", chatId];
+    const queryKey = queryKeys.chatMessages.byChat(chatId);
     const queryHash = JSON.stringify(queryKey);
 
     setData(queryClient.getQueryData(queryKey));

--- a/src/hooks/chats/useChatMessages.ts
+++ b/src/hooks/chats/useChatMessages.ts
@@ -1,10 +1,11 @@
 import { useInfiniteQuery } from "@tanstack/react-query";
 import { getChatMessages } from "@/services/chats/getChatMessages";
 import { PaginatedMessagesResponse } from "@/types/chatsTypes";
+import { queryKeys } from "@/lib/queryKeys";
 
 export function useChatMessagesQuery(chatId?: string) {
   return useInfiniteQuery<PaginatedMessagesResponse, Error>({
-    queryKey: ["chatMessages", chatId],
+    queryKey: queryKeys.chatMessages.byChat(chatId),
     queryFn: ({ pageParam }) =>
       getChatMessages(chatId!, pageParam as number),
     initialPageParam: 0,

--- a/src/hooks/chats/useChatSocket.ts
+++ b/src/hooks/chats/useChatSocket.ts
@@ -6,6 +6,7 @@ import { Client } from "@stomp/stompjs";
 import { Message, PaginatedMessagesResponse } from "@/types/chatsTypes";
 import { InfiniteData, useQueryClient } from "@tanstack/react-query";
 import { useChatStore } from "@/stores/useChatStore";
+import { queryKeys } from "@/lib/queryKeys";
 
 const MAX_RECONNECT_ATTEMPTS = 5;
 const SEND_TIMEOUT_MS = 5000;
@@ -138,7 +139,7 @@ export function useChatSocket({ currentUserId }: UseChatSocketParams) {
         }
 
         queryClient.setQueryData<InfiniteData<PaginatedMessagesResponse>>(
-          ["chatMessages", msg.chatId],
+          queryKeys.chatMessages.byChat(msg.chatId),
           prev => {
             if (!prev) return prev;
 
@@ -205,7 +206,7 @@ export function useChatSocket({ currentUserId }: UseChatSocketParams) {
 
         if (!targetChatId) {
           const allQueries = queryClient.getQueryCache().findAll({
-            queryKey: ["chatMessages"],
+            queryKey: queryKeys.chatMessages.all,
           });
 
           for (const query of allQueries) {
@@ -230,7 +231,7 @@ export function useChatSocket({ currentUserId }: UseChatSocketParams) {
         if (!targetChatId) return;
 
         queryClient.setQueryData<InfiniteData<PaginatedMessagesResponse>>(
-          ["chatMessages", targetChatId],
+          queryKeys.chatMessages.byChat(targetChatId),
           prev => {
             if (!prev) return prev;
 
@@ -372,7 +373,7 @@ export function useChatSocket({ currentUserId }: UseChatSocketParams) {
 
   const markAsRead = useCallback((chatId: string, messageId: string) => {
     queryClient.setQueryData<InfiniteData<PaginatedMessagesResponse>>(
-      ["chatMessages", chatId],
+      queryKeys.chatMessages.byChat(chatId),
       prev => {
         if (!prev) return prev;
 

--- a/src/hooks/chats/useChats.ts
+++ b/src/hooks/chats/useChats.ts
@@ -1,9 +1,10 @@
 import { useQuery } from "@tanstack/react-query";
 import { fetchChats } from "@/services/chats/fetchChats";
+import { queryKeys } from "@/lib/queryKeys";
 
 export function useChatsQuery() {
   return useQuery({
-    queryKey: ["chats"],
+    queryKey: queryKeys.chats.all,
     queryFn: fetchChats,
     retry: false,
   });

--- a/src/hooks/owners/useProfile.ts
+++ b/src/hooks/owners/useProfile.ts
@@ -1,9 +1,10 @@
 import { useQuery } from "@tanstack/react-query";
 import { getProfileClient } from "@/services/auth/getProfile.client";
+import { queryKeys } from "@/lib/queryKeys";
 
 export function useProfile() {
   return useQuery({
-    queryKey: ["profile"],
+    queryKey: queryKeys.profile,
     queryFn: getProfileClient,
     staleTime: 1000 * 60 * 5,
     retry: false,

--- a/src/hooks/owners/useUpdateProfile.ts
+++ b/src/hooks/owners/useUpdateProfile.ts
@@ -1,5 +1,6 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import updateProfile from "@/services/owners/updateProfile";
+import { queryKeys } from "@/lib/queryKeys";
 
 export function useUpdateProfile() {
   const queryClient = useQueryClient();
@@ -8,7 +9,7 @@ export function useUpdateProfile() {
     mutationFn: updateProfile,
 
     onSuccess: (data) => {
-      queryClient.setQueryData(["profile"], data);
+      queryClient.setQueryData(queryKeys.profile, data);
     },
   });
 }

--- a/src/hooks/pets/useAddPet.ts
+++ b/src/hooks/pets/useAddPet.ts
@@ -1,5 +1,6 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { addPet } from "@/services/pets/addPet";
+import { queryKeys } from "@/lib/queryKeys";
 
 export function useAddPet() {
   const queryClient = useQueryClient();
@@ -8,7 +9,7 @@ export function useAddPet() {
     mutationFn: addPet,
 
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["pets"] });
+      queryClient.invalidateQueries({ queryKey: queryKeys.pets.all });
     },
   });
 }

--- a/src/hooks/pets/useAddPetAvatar.ts
+++ b/src/hooks/pets/useAddPetAvatar.ts
@@ -1,5 +1,6 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { addPetAvatar } from "@/services/pets/addPetAvatar";
+import { queryKeys } from "@/lib/queryKeys";
 
 interface AddPetAvatarInput {
   petId: string;
@@ -18,8 +19,8 @@ export function useAddPetAvatar() {
     },
 
     onSuccess: (petId) => {
-      queryClient.invalidateQueries({ queryKey: ["pet", petId] });
-      queryClient.invalidateQueries({ queryKey: ["pets"] });
+      queryClient.invalidateQueries({ queryKey: queryKeys.pets.detail(petId) });
+      queryClient.invalidateQueries({ queryKey: queryKeys.pets.all });
     },
   });
 }

--- a/src/hooks/pets/useGetPets.ts
+++ b/src/hooks/pets/useGetPets.ts
@@ -1,10 +1,11 @@
 import { useQuery } from "@tanstack/react-query";
 import { getPets } from "@/services/pets/getPets";
 import { Pet } from "@/types/pet";
+import { queryKeys } from "@/lib/queryKeys";
 
 export function useGetPets() {
   return useQuery<Pet[], Error>({
-    queryKey: ["pets"],
+    queryKey: queryKeys.pets.all,
     queryFn: getPets,
   });
 }

--- a/src/hooks/vets/useFreeScheduleSlots.ts
+++ b/src/hooks/vets/useFreeScheduleSlots.ts
@@ -1,9 +1,10 @@
 import { useQuery } from "@tanstack/react-query";
 import { fetchFreeScheduleSlots } from "@/services/vets/fetchFreeScheduleSlots";
+import { queryKeys } from "@/lib/queryKeys";
 
 export function useFreeScheduleSlots(vetId: string) {
   return useQuery({
-    queryKey: ["free-schedule-slots", vetId],
+    queryKey: queryKeys.vets.freeSlots(vetId),
     queryFn: () =>
       fetchFreeScheduleSlots(vetId),
     enabled: !!vetId,

--- a/src/hooks/vets/useScheduleSlots.ts
+++ b/src/hooks/vets/useScheduleSlots.ts
@@ -1,10 +1,11 @@
 import { useQuery } from "@tanstack/react-query";
 import { Dayjs } from "dayjs";
 import { fetchScheduleSlots } from "@/services/vets/fetchScheduleSlots";
+import { queryKeys } from "@/lib/queryKeys";
 
 export function useScheduleSlots(vetId: string, date: Dayjs | null) {
   return useQuery({
-    queryKey: ["schedule-slots", vetId, date?.format("YYYY-MM-DD")],
+    queryKey: queryKeys.vets.scheduleSlots(vetId, date?.format("YYYY-MM-DD")),
     queryFn: () =>
       fetchScheduleSlots(vetId, date!.format("YYYY-MM-DD")),
     enabled: !!vetId && !!date,

--- a/src/hooks/vets/useVets.ts
+++ b/src/hooks/vets/useVets.ts
@@ -2,10 +2,11 @@ import { useQuery } from "@tanstack/react-query";
 import { getVetsByCriteria } from "@/services/vets/getVetsByCriteria";
 import { GetVetsParams } from "@/types/vetTypes";
 import { VetsResponse } from "@/types/vetTypes";
+import { queryKeys } from "@/lib/queryKeys";
 
 export function useVetsByCriteria(params: GetVetsParams) {
   return useQuery<VetsResponse>({
-    queryKey: ["vetsByCriteria", params],
+    queryKey: queryKeys.vets.byCriteria(params),
     queryFn: () => getVetsByCriteria(params),
     refetchOnWindowFocus: false,
   });

--- a/src/lib/queryKeys.ts
+++ b/src/lib/queryKeys.ts
@@ -1,0 +1,47 @@
+import type { GetVetsParams } from "@/types/vetTypes";
+
+/**
+ * Centralised React Query key factory.
+ *
+ * Every `useQuery` / `useInfiniteQuery` / `invalidateQueries` / `setQueryData`
+ * call should source its key from here instead of hand-writing string arrays.
+ * This removes "magic string" drift — e.g. a mutation invalidating `["pets"]`
+ * while a query reads `["pet"]` — and gives one place to see the whole cache
+ * surface.
+ *
+ * IMPORTANT: the arrays returned here are byte-for-byte identical to the keys
+ * previously written inline. Some consumers depend on the exact shape:
+ * `useCachedChatMessages` compares `JSON.stringify(key)` against the cache's
+ * `queryHash`, and `useChatSocket` reads `query.queryKey[1]`. Do not reorder or
+ * rename existing elements — only add new keys.
+ *
+ * Convention: `all` is the broad key (used for invalidation / partial match),
+ * factory functions return the specific key for a single entity.
+ */
+export const queryKeys = {
+  profile: ["profile"] as const,
+
+  pets: {
+    all: ["pets"] as const,
+    detail: (petId: string) => ["pet", petId] as const,
+  },
+
+  chats: {
+    all: ["chats"] as const,
+  },
+
+  /** Paginated messages of a single chat (infinite query). */
+  chatMessages: {
+    /** Broad key matching every chat's messages (used with `findAll`). */
+    all: ["chatMessages"] as const,
+    byChat: (chatId?: string) => ["chatMessages", chatId] as const,
+  },
+
+  vets: {
+    byCriteria: (params: GetVetsParams) =>
+      ["vetsByCriteria", params] as const,
+    freeSlots: (vetId: string) => ["free-schedule-slots", vetId] as const,
+    scheduleSlots: (vetId: string, date?: string) =>
+      ["schedule-slots", vetId, date] as const,
+  },
+} as const;

--- a/src/services/auth/fetchProfileAndDehydrate.ts
+++ b/src/services/auth/fetchProfileAndDehydrate.ts
@@ -1,10 +1,11 @@
 import { getProfileSSR } from "@/services/auth/getProfile.server";
 import { getQueryClient } from "@/lib/getQueryClient";
 import { dehydrate } from "@tanstack/react-query";
+import { queryKeys } from "@/lib/queryKeys";
 
 export async function fetchProfileAndDehydrate() {
   const queryClient = getQueryClient();
   const profile = await getProfileSSR();
-  queryClient.setQueryData(["profile"], profile);
+  queryClient.setQueryData(queryKeys.profile, profile);
   return { queryClient, profile, dehydratedState: dehydrate(queryClient) };
 }


### PR DESCRIPTION
Add src/lib/queryKeys.ts as the single source of truth for all query keys and route every useQuery/useInfiniteQuery/invalidateQueries/ setQueryData/getQueryData call through it (profile, pets, pet detail, chats, chat messages, vets search, free/schedule slots).

Removes hand-written "magic string" key arrays scattered across 16 files, eliminating the drift risk where a mutation invalidates one key shape while a query reads another. Returned arrays are byte-identical to the previous inline keys, so cache behaviour is unchanged — including useCachedChatMessages' JSON.stringify(key) === queryHash comparison and useChatSocket's queryKey[1] reads.