### PR TITLE
fix(veterinarians): guard invalid date in NotFoundVet to prevent toISOString crash

### DIFF
--- a/src/components/VeterinariansBlock/NotFoundVet.tsx
+++ b/src/components/VeterinariansBlock/NotFoundVet.tsx
@@ -3,27 +3,35 @@ import { DaysUa, MonthsUaShort } from "@/utils/constsVet";
 import Image from "next/image";
 import { Button } from "@heroui/react";
 import { useEffect, useMemo, useState } from "react";
-import { useRouter } from "next/navigation";
+import { usePathname, useRouter } from "next/navigation";
+import { parseValidDate } from "@/utils/date/parseValidDate";
 
 export default function NotFoundVet({ dateStr }: { dateStr?: string }) {
   const router = useRouter();
-  const selectedDate = new Date(dateStr || "");
+  const pathname = usePathname();
   const today = new Date();
   today.setHours(0, 0, 0, 0);
+
+  const selectedDate = useMemo(() => {
+    const parsed = parseValidDate(dateStr);
+    if (parsed) return parsed;
+    const fallback = new Date();
+    fallback.setHours(0, 0, 0, 0);
+    return fallback;
+  }, [dateStr]);
 
   const dateButtons = useMemo(() => {
     const buttons = [];
     const totalDays = 5;
-  
-  
+
     for (let i = 1; buttons.length < totalDays; i++) {
       const next = new Date(selectedDate);
       next.setDate(selectedDate.getDate() + i);
       buttons.push(next);
     }
-  
+
     return buttons;
-  }, [dateStr]);
+  }, [selectedDate]);
 
   const formatBtnDate = (date: Date) => {
     const day = date.getDate();
@@ -45,7 +53,7 @@ export default function NotFoundVet({ dateStr }: { dateStr?: string }) {
     const params = new URLSearchParams(window.location.search);
     params.set("date", newDate);
   
-    router.push(`/veterinarians?${params.toString()}`);
+    router.push(`${pathname}?${params.toString()}`);
   };
 
   const [isMobile, setIsMobile] = useState(false);

--- a/src/utils/date/parseValidDate.ts
+++ b/src/utils/date/parseValidDate.ts
@@ -1,0 +1,5 @@
+export function parseValidDate(value?: string | null): Date | null {
+  if (!value) return null;
+  const date = new Date(value);
+  return isNaN(date.getTime()) ? null : date;
+}


### PR DESCRIPTION
Empty/invalid date query param produced an Invalid Date, so building the suggested-date buttons threw RangeError: Invalid time value via .toISOString(). Add a parseValidDate helper and fall back to today. Also keep the suggested-date redirect on the current path (usePathname) so /owner/veterinarians no longer bounces to the public /veterinarians.