### PR TITLE
chore: remove redundant descriptive comments

### DIFF
--- a/src/app/(site)/veterinarians/[id]/booking/page.tsx
+++ b/src/app/(site)/veterinarians/[id]/booking/page.tsx
@@ -173,7 +173,6 @@ export default function BookingPage() {
       </div>
       <div className="text-gray-500 pt-5 md:pt-8">
         <div className="flex flex-col lg:flex-row gap-6 mt-6">
-          {/* Левая колонка - форма */}
           <div className="lg:w-1/2 bg-white p-6 rounded-lg">
             <h1 className="text-2xl font-bold text-gray-900 mb-6">
               Бронювання запису

--- a/src/app/(site)/veterinarians/[id]/booking/stepper.tsx
+++ b/src/app/(site)/veterinarians/[id]/booking/stepper.tsx
@@ -14,7 +14,6 @@ const Stepper: React.FC<{ steps: Step[] }> = ({ steps }) => {
         return (
           <React.Fragment key={index}>
             <div className="flex flex-col items-center relative">
-              {/* Кружок */}
               <div
                 className={`w-8 h-8 rounded-full flex items-center justify-center border-2 transition-all duration-300 z-10
                   ${
@@ -44,7 +43,6 @@ const Stepper: React.FC<{ steps: Step[] }> = ({ steps }) => {
                   index + 1
                 )}
               </div>
-              {/* Название шага */}
               <span
                 className={`mt-2 text-sm font-medium ${
                   step.status === "active"
@@ -58,7 +56,6 @@ const Stepper: React.FC<{ steps: Step[] }> = ({ steps }) => {
               </span>
             </div>
 
-            {/* Линия между кружками */}
             {!isLast && (
               <div
                 className={`flex-1 h-0.5 mx-2 transition-all duration-300 mb-6

--- a/src/components/DoctorPage/EducationTab.tsx
+++ b/src/components/DoctorPage/EducationTab.tsx
@@ -13,7 +13,6 @@ const EducationTab = ({ veterinarian }: Props) => {
 
   return (
     <div className="flex flex-col gap-6">
-      {/* Загальна освіта */}
       <div>
         <h3 className="text-[16px]  md:text-[18px] lg:text-[18px] font-semibold mb-4">
           Загальна освіта
@@ -48,8 +47,6 @@ const EducationTab = ({ veterinarian }: Props) => {
           </div>
         )}
       </div>
-
-      {/* Додаткова освіта */}
 
       <h3 className="text-[16px]  md:text-[18px] lg:text-[18px] font-semibold mb-4">
         Додаткова освіта

--- a/src/components/Form/FormDatePicker.tsx
+++ b/src/components/Form/FormDatePicker.tsx
@@ -27,10 +27,6 @@ interface FormDatePickerProps<T extends FieldValues> {
   placeholder?: string;
 }
 
-/**
- * Calendar field wired to react-hook-form. The form value is a `YYYY-MM-DD`
- * string; the popover calendar reads/writes it as a `Date`.
- */
 export function FormDatePicker<T extends FieldValues>({
   control,
   name,

--- a/src/components/Form/FormInput.tsx
+++ b/src/components/Form/FormInput.tsx
@@ -3,7 +3,6 @@
 import { Input } from "@heroui/react";
 import { Control, FieldValues, Path, useController } from "react-hook-form";
 
-/** Shared field styling, reused by the other form primitives and static fields. */
 export const formLabelClass =
   "block text-[12px] font-[500] leading-[1.4] text-gray-700 mb-[8px]";
 
@@ -24,7 +23,6 @@ interface FormInputProps<T extends FieldValues> {
   isRequired?: boolean;
 }
 
-/** HeroUI text input wired to react-hook-form via `control` + `name`. */
 export function FormInput<T extends FieldValues>({
   control,
   name,

--- a/src/components/Form/FormSelect.tsx
+++ b/src/components/Form/FormSelect.tsx
@@ -18,7 +18,6 @@ interface FormSelectProps<T extends FieldValues> {
   placeholder?: string;
 }
 
-/** HeroUI single-select wired to react-hook-form via `control` + `name`. */
 export function FormSelect<T extends FieldValues>({
   control,
   name,

--- a/src/lib/handleApiError.ts
+++ b/src/lib/handleApiError.ts
@@ -1,4 +1,3 @@
-/** Reads the error text from a failed `Response`, or `fallback` if empty/unreadable. */
 export async function extractErrorMessage(
   res: Response,
   fallback = "Request failed",

--- a/src/lib/queryKeys.ts
+++ b/src/lib/queryKeys.ts
@@ -1,9 +1,6 @@
 import type { GetVetsParams } from "@/types/vetTypes";
 
 /**
- * Central React Query key factory — single source of truth for query keys, so a
- * mutation and a query can't drift onto mismatched key shapes.
- *
  * Keys stay byte-identical to the previous inline arrays on purpose:
  * `useCachedChatMessages` compares `JSON.stringify(key)` to the cache queryHash
  * and `useChatSocket` reads `queryKey[1]`, so don't reorder existing elements —
@@ -22,7 +19,6 @@ export const queryKeys = {
   },
 
   chatMessages: {
-    /** Broad key matching every chat's messages (used with `findAll`). */
     all: ["chatMessages"] as const,
     byChat: (chatId?: string) => ["chatMessages", chatId] as const,
   },


### PR DESCRIPTION
Drop JSDoc and JSX section-label comments that only restate what the code does (form primitives, query-key factory intro, error helper, stepper and education section labels). Keep why/warning comments (queryKeys reorder note, FormDatePicker local-date rationale) and all commented-out code.