### PR TITLE
Fix mobile footer copyright alignment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 !.yarn/plugins
 !.yarn/releases
 !.yarn/versions
+.idea
 
 # testing
 /coverage

--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,6 @@
 !.yarn/plugins
 !.yarn/releases
 !.yarn/versions
-.idea
 
 # testing
 /coverage

--- a/src/components/Footer/CopyrightFooter.tsx
+++ b/src/components/Footer/CopyrightFooter.tsx
@@ -1,7 +1,7 @@
 export const CopyrightFooter = () => {
   return (
-    <div className="text-primary-300 text-center text-[12px] lg:text-[14px]  pb-4">
-      © PetHelsi. Всі права захищені. 2025
+    <div className="w-full mb-4 text-left md:text-center text-[12px] leading-6 text-primary-300 lg:text-[14px]">
+        © PetHelsi. Всі права захищені. 2025
     </div>
   );
 };


### PR DESCRIPTION
Fixed copyright text alignment in the footer according to the mobile Figma design.

Changes:
- Left-align copyright text on mobile.
- Keep centered alignment from md breakpoint and above.
- Avoided extra horizontal spacing because the parent footer already provides px-4 / md:px-10.
- Verified that ESLint and git diff --check pass.