### PR TITLE
fix: add FAQ expand indicators

### DIFF
--- a/src/components/Landing/Faq.tsx
+++ b/src/components/Landing/Faq.tsx
@@ -79,7 +79,7 @@ export default function Faq() {
                   id={isOpen ? "icon-minus" : "icon-plus"}
                   width="24px"
                   height="24px"
-                  className="fill-primary !rotate-90"
+                  className="stroke-primary-700 fill-none shrink-0 !rotate-90"
                 />
               )}>
               <ol className="lg:pb-10 lg:px-6">


### PR DESCRIPTION
Added missing expand indicators for the FAQ block.

Changes:

- Added plus icons/indicators for FAQ items
- Updated FAQ UI to better match the expected design
- Kept the changes focused only on the FAQ block

Testing:

- Checked that FAQ items display expand indicators
- Verified that the indicators are visible in the relevant layout
- Confirmed that unrelated sections were not affected